### PR TITLE
feat: Change custom text source name from Japanese to English (#20)

### DIFF
--- a/src/components/CompactTextSourceSelector.tsx
+++ b/src/components/CompactTextSourceSelector.tsx
@@ -23,7 +23,7 @@ const COMPACT_TEXT_SOURCES: TextSourceConfig[] = [
   },
   {
     id: 'custom',
-    name: 'カスタム',
+    name: 'Custom',
     description: 'URL取得',
     texts: []
   }

--- a/src/components/ElegantTextSourceSelector.tsx
+++ b/src/components/ElegantTextSourceSelector.tsx
@@ -24,7 +24,7 @@ const ELEGANT_TEXT_SOURCES: TextSourceConfig[] = [
     },
   {
     id: 'custom',
-    name: 'カスタム',
+    name: 'Custom',
     description: '任意のWebページから抽出',
     texts: []
   }


### PR DESCRIPTION
## Summary
- Changed "カスタム" to "Custom" in both text source selectors
- Updated CompactTextSourceSelector and ElegantTextSourceSelector components
- Improves internationalization and UI consistency

## Test plan
- [x] Custom text source displays as "Custom" instead of "カスタム"
- [x] Functionality remains unchanged
- [x] Both compact and elegant selectors updated
- [x] No breaking changes to existing behavior

🤖 Generated with [Claude Code](https://claude.ai/code)